### PR TITLE
Remove linux arm64

### DIFF
--- a/.github/workflows/build-snapshot.yaml
+++ b/.github/workflows/build-snapshot.yaml
@@ -13,5 +13,4 @@ jobs:
     uses: ./.github/workflows/build.yaml
     secrets: inherit
     with:
-      linux-arm64: true
       linux-appimage: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,9 +3,6 @@ name: Build app
 on:
   workflow_call:
     inputs:
-      linux-arm64:
-        default: false
-        type: boolean
       linux-appimage:
         default: false
         type: boolean
@@ -43,9 +40,6 @@ jobs:
               cwd: ui/
               args: [--frozen-lockfile]
           version: ${{ env.PNPM_VERSION }}
-      - name: Setup QEMU
-        if: inputs.linux-arm64 && runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
       - name: Setup Linux deps
         if: runner.os == 'Linux'
         run: |
@@ -62,9 +56,6 @@ jobs:
       - name: Build x86_64 binary
         if: runner.os == 'Linux'
         run: make build/linux
-      - name: Build arm64 binary
-        if: runner.os == 'Linux' && inputs.linux-arm64
-        run: make linux-builder/binary-arm64
       - name: Build AppImage
         if: runner.os == 'Linux' && inputs.linux-appimage
         run: make linux-builder/appimage

--- a/.github/workflows/linux-builder.yaml
+++ b/.github/workflows/linux-builder.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/linux-builder.yaml
+++ b/.github/workflows/linux-builder.yaml
@@ -3,8 +3,6 @@ name: Build Linux builder images
 on:
   workflow_dispatch:
   push:
-    branches:
-    - main
     paths:
       - '.github/workflows/linux-builder.yaml'
       - 'build/linux/wails.Dockerfile'
@@ -12,23 +10,6 @@ on:
       - 'build/linux/pack-appimage.sh'
 
 jobs:
-  arm64:
-    name: Build aarch64 image builder
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Docker BuildX
-        uses: docker/setup-buildx-action@v2
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build image
-        run: make linux-builder/image-arm64
-      - name: Push image
-        run: make linux-builder/push-image-arm64
   amd64:
     name: Build amd64 image builder
     runs-on: ubuntu-latest

--- a/.github/workflows/quality-assurance.yaml
+++ b/.github/workflows/quality-assurance.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Generate Wails JS bindings
         run: wails generate module
       - name: Lint with golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           args: --config=./.golangci.yaml
           skip-cache: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,6 @@ jobs:
     uses: ./.github/workflows/build.yaml
     secrets: inherit
     with:
-      linux-arm64: true
       linux-appimage: true
       mac-notarize: true
   release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning][].
 
 - Macros configuration support.
 
+### Removed
+
+- Linux arm64 build. You can still build via `make linux-builder/binary-arm64`.
+
 ## [2.2.1]
 
 ### Fixed

--- a/build/linux/pack-appimage.sh
+++ b/build/linux/pack-appimage.sh
@@ -9,7 +9,6 @@ pack_arch() {
 
 if [ -z "$1" ]; then
   pack_arch amd64
-  pack_arch arm64
 else
   pack_arch "$1"
 fi

--- a/makefiles/linux-builder.mk
+++ b/makefiles/linux-builder.mk
@@ -92,7 +92,6 @@ linux-builder/appimage: $(DIST_PATH)
 		--volume ".:/opt/nuga" \
 		"$(APPIMAGE_BUILDER_IMAGE):latest" \
 		pack-appimage
-	$(call copy_appimage,aarch64,arm64)
 	$(call copy_appimage,x86_64,amd64)
 
 


### PR DESCRIPTION
Building via buildx and qemu is too long. Cross-compiling Wails for Linux is not supported yet.

You can still build via `make linux-builder/binary-arm64`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed Linux arm64 build support from various workflow configurations.
- **Refactor**
	- Updated Docker login action to version 3 in CI workflows.
- **Bug Fixes**
	- Corrected the default architecture to amd64 for AppImage packaging.
- **Documentation**
	- Updated CHANGELOG to reflect removal of Linux arm64 build support.
- **Tests**
	- Updated linting tool version in quality assurance workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->